### PR TITLE
Any-type support for KeptList, Collection, Queue, BlockingQueue

### DIFF
--- a/src/java/net/killa/kept/KeptBlockingQueue.java
+++ b/src/java/net/killa/kept/KeptBlockingQueue.java
@@ -36,98 +36,104 @@ import org.apache.zookeeper.data.ACL;
  * may be a delay between modifying the queue and it reflecting the change.
  * 
  */
-public class KeptBlockingQueue extends KeptQueue implements BlockingQueue<String> {
-	/**
-	 * Construct a KeptBlockingQueue.
-	 * 
-	 * @param keeper
-	 *            A {@link ZooKeeper} that is synchronized with
-	 * 
-	 * @param znode
-	 *            A {@link String} containing the znode whose children will be
-	 *            members of the set
-	 * 
-	 * @param acl
-	 *            A {@link List} of {@link ACL} containing the access control
-	 *            lists for child node creation
-	 * 
-	 * @param mode
-	 *            A {@link CreateMode} representing the persistence of created
-	 *            child nodes
-	 * 
-	 * @throws KeeperException
-	 * @throws InterruptedException
-	 */
-	public KeptBlockingQueue(ZooKeeper keeper, String znode, List<ACL> acl, CreateMode mode) throws KeeperException, InterruptedException {
-		super(keeper, znode, acl, mode);
-	}
+public class KeptBlockingQueue<T> extends KeptQueue<T> implements
+        BlockingQueue<T> {
+    /**
+     * Construct a KeptBlockingQueue.
+     * 
+     * @param keeper
+     *            A {@link ZooKeeper} that is synchronized with
+     * 
+     * @param znode
+     *            A {@link String} containing the znode whose children will be
+     *            members of the set
+     * 
+     * @param acl
+     *            A {@link List} of {@link ACL} containing the access control
+     *            lists for child node creation
+     * 
+     * @param mode
+     *            A {@link CreateMode} representing the persistence of created
+     *            child nodes
+     * 
+     * @throws KeeperException
+     * @throws InterruptedException
+     */
+    public KeptBlockingQueue(ZooKeeper keeper, String znode, List<ACL> acl,
+            CreateMode mode) throws KeeperException, InterruptedException {
+        super(keeper, znode, acl, mode);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public int drainTo(Collection<? super String> c) {
-		return this.drainTo(c, Integer.MAX_VALUE);
-	}
+    /** {@inheritDoc} */
+    @Override
+    public int drainTo(Collection<? super T> c) {
+        return this.drainTo(c, Integer.MAX_VALUE);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public int drainTo(Collection<? super String> c, int maxElements) {
-		synchronized (this.elements) {
-			int size = Math.min(this.size(), maxElements);
+    /** {@inheritDoc} */
+    @Override
+    public int drainTo(Collection<? super T> c, int maxElements) {
+        synchronized (this.elements) {
+            int size = Math.min(this.size(), maxElements);
 
-			c.addAll(this.subList(0, size));
+            c.addAll(this.subList(0, size));
 
-			try {
-				for (int i = 0; i < size; i++)
-					this.removeUnsynchronized(i);
-			} catch (InterruptedException e) {
-				throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-			} catch (KeeperException e) {
-				throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-			}
+            try {
+                for (int i = 0; i < size; i++)
+                    this.removeUnsynchronized(i);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            } catch (KeeperException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            }
 
-			return size;
-		}
-	}
+            return size;
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean offer(String o, long timeout, TimeUnit unit) throws InterruptedException {
-		// no capacity limitations for this queue (yet)
-		return this.offer(o);
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean offer(T o, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        // no capacity limitations for this queue (yet)
+        return this.offer(o);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public String poll(long timeout, TimeUnit unit) throws InterruptedException {
-		long last = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(timeout, unit);
+    /** {@inheritDoc} */
+    @Override
+    public T poll(long timeout, TimeUnit unit) throws InterruptedException {
+        long last = System.currentTimeMillis()
+                + TimeUnit.MILLISECONDS.convert(timeout, unit);
 
-		do {
-			String element = this.poll();
+        do {
+            T element = this.poll();
 
-			if (element != null)
-				return element;
+            if (element != null)
+                return element;
 
-			Thread.sleep(100);
-		} while (System.currentTimeMillis() <= last);
+            Thread.sleep(100);
+        } while (System.currentTimeMillis() <= last);
 
-		return null;
-	}
+        return null;
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public void put(String o) throws InterruptedException {
-		this.offer(o);
-	}
+    /** {@inheritDoc} */
+    @Override
+    public void put(T o) throws InterruptedException {
+        this.offer(o);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public int remainingCapacity() {
-		return Integer.MAX_VALUE;
-	}
+    /** {@inheritDoc} */
+    @Override
+    public int remainingCapacity() {
+        return Integer.MAX_VALUE;
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public String take() throws InterruptedException {
-		return this.poll(Long.MAX_VALUE, TimeUnit.DAYS);
-	}
+    /** {@inheritDoc} */
+    @Override
+    public T take() throws InterruptedException {
+        return this.poll(Long.MAX_VALUE, TimeUnit.DAYS);
+    }
 }

--- a/src/java/net/killa/kept/KeptCollection.java
+++ b/src/java/net/killa/kept/KeptCollection.java
@@ -17,6 +17,7 @@
  */
 package net.killa.kept;
 
+import java.io.IOException;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,275 +41,321 @@ import org.apache.zookeeper.data.ACL;
  * may be a delay between modifying the list and it reflecting the change.
  * 
  */
-public class KeptCollection implements Collection<String>, Synchronizable {
-	private final SynchronizingWatcher watcher;
-	protected final ArrayList<String> elements;
+public class KeptCollection<T> implements Collection<T>, Synchronizable {
+    private final SynchronizingWatcher watcher;
+    protected final List<T> elements;
 
-	private final ZooKeeper keeper;
-	private final String znode;
-	private final List<ACL> acl;
-	private final CreateMode createMode;
+    private final ZooKeeper keeper;
+    private final String znode;
+    private final List<ACL> acl;
+    private final CreateMode createMode;
 
-	/**
-	 * Construct a KeptCollection.
-	 * 
-	 * @param keeper
-	 *            A {@link ZooKeeper} that is synchronized with
-	 * 
-	 * @param znode
-	 *            A {@link String} containing the znode whose children will be
-	 *            members of the collection
-	 * 
-	 * @param acl
-	 *            A {@link List} of {@link ACL} containing the access control
-	 *            lists for child node creation
-	 * 
-	 * @param createMode
-	 *            A {@link CreateMode}, representing the mode of created
-	 *            children.
-	 * 
-	 * @throws KeeperException
-	 * @throws InterruptedException
-	 * 
-	 */
-	public KeptCollection(ZooKeeper keeper, String znode, List<ACL> acl, CreateMode createMode) throws KeeperException, InterruptedException {
-		this.elements = new ArrayList<String>();
+    /**
+     * Construct a KeptCollection.
+     * 
+     * @param keeper
+     *            A {@link ZooKeeper} that is synchronized with
+     * 
+     * @param znode
+     *            A {@link String} containing the znode whose children will be
+     *            members of the collection
+     * 
+     * @param acl
+     *            A {@link List} of {@link ACL} containing the access control
+     *            lists for child node creation
+     * 
+     * @param createMode
+     *            A {@link CreateMode}, representing the mode of created
+     *            children.
+     * 
+     * @throws KeeperException
+     * @throws InterruptedException
+     * 
+     */
+    public KeptCollection(ZooKeeper keeper, String znode, List<ACL> acl,
+            CreateMode createMode) throws KeeperException, InterruptedException {
+        this.elements = new ArrayList<T>();
 
-		this.keeper = keeper;
+        this.keeper = keeper;
 
-		// if the znode doesn't exist, create a permanent znode with that path
-		// TODO: change to allow ephemeral znode when ephemeral parents are
-		// supported by zookeeper
-		try {
-			if (this.keeper.exists(znode, false) == null)
-				this.keeper.create(znode, new byte[0], acl, CreateMode.PERSISTENT);
-		} catch (KeeperException.NodeExistsException e) {
-			// ignore this exception
-		}
+        // if the znode doesn't exist, create a permanent znode with that path
+        // TODO: change to allow ephemeral znode when ephemeral parents are
+        // supported by zookeeper
+        try {
+            if (this.keeper.exists(znode, false) == null)
+                this.keeper.create(znode, new byte[0], acl,
+                        CreateMode.PERSISTENT);
+        } catch (KeeperException.NodeExistsException e) {
+            // ignore this exception
+        }
 
-		this.znode = znode;
-		this.acl = acl;
-		if (createMode == CreateMode.PERSISTENT_SEQUENTIAL || createMode == CreateMode.EPHEMERAL_SEQUENTIAL)
-			this.createMode = createMode;
-		else if (createMode == CreateMode.PERSISTENT)
-			this.createMode = CreateMode.PERSISTENT_SEQUENTIAL;
-		else if (createMode == CreateMode.EPHEMERAL)
-			this.createMode = CreateMode.EPHEMERAL_SEQUENTIAL;
-		else
-			throw new InvalidParameterException("unexpected create mode " + createMode.toString());
+        this.znode = znode;
+        this.acl = acl;
+        if (createMode == CreateMode.PERSISTENT_SEQUENTIAL
+                || createMode == CreateMode.EPHEMERAL_SEQUENTIAL)
+            this.createMode = createMode;
+        else if (createMode == CreateMode.PERSISTENT)
+            this.createMode = CreateMode.PERSISTENT_SEQUENTIAL;
+        else if (createMode == CreateMode.EPHEMERAL)
+            this.createMode = CreateMode.EPHEMERAL_SEQUENTIAL;
+        else
+            throw new InvalidParameterException("unexpected create mode "
+                    + createMode.toString());
 
-		this.watcher = new SynchronizingWatcher(this);
+        this.watcher = new SynchronizingWatcher(this);
 
-		this.synchronize();
-	}
+        this.synchronize();
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public void synchronize() throws KeeperException, InterruptedException {
-		synchronized (this.elements) {
-			try {
-				// clear out the cache and reload it
-				this.elements.clear();
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    @Override
+    public void synchronize() throws KeeperException, InterruptedException {
+        synchronized (this.elements) {
+            try {
+                // clear out the cache and reload it
+                this.elements.clear();
 
-				for (String s : this.keeper.getChildren(this.znode, this.watcher))
-					this.elements.add(new String(this.keeper.getData(this.znode + '/' + s, false, null)));
-			} catch (KeeperException.SessionExpiredException e) {
-				// ignore it
-			}
-		}
-	}
+                for (String s : this.keeper.getChildren(this.znode,
+                        this.watcher)) {
+                    this.elements.add((T) Transformer.bytesToObject(this.keeper
+                            .getData(this.znode + '/' + s, false, null)));
+                }
+            } catch (KeeperException.SessionExpiredException e) {
+                // ignore it
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            } catch (IOException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            }
+        }
+    }
 
-	protected boolean addUnsynchronized(String s) throws KeeperException, InterruptedException {
-		this.keeper.create(this.znode + "/entry-", s.getBytes(), this.acl, this.createMode);
+    protected boolean addUnsynchronized(Object o) throws KeeperException,
+            InterruptedException, IOException {
+        this.keeper.create(this.znode + "/entry-",
+                Transformer.objectToBytes(o), this.acl, this.createMode);
 
-		return true;
-	}
+        return true;
+    }
 
-	protected boolean removeUnsynchronized(Object o) throws InterruptedException, KeeperException {
-		String string = o.toString();
+    protected boolean removeUnsynchronized(Object o)
+            throws InterruptedException, KeeperException, IOException {
+        for (String s : this.keeper.getChildren(this.znode, this.watcher))
+            if (Arrays.equals(this.keeper.getData(this.znode + '/' + s, false,
+                    null), Transformer.objectToBytes(o))) {
+                this.keeper.delete(this.znode + '/' + s, -1);
 
-		for (String s : this.keeper.getChildren(this.znode, this.watcher))
-			if (Arrays.equals(this.keeper.getData(this.znode + '/' + s, false, null), string.getBytes())) {
-				this.keeper.delete(this.znode + '/' + s, -1);
+                return true;
+            }
 
-				return true;
-			}
+        return false;
+    }
 
-		return false;
-	}
+    /**
+     * {@inheritDoc} NB: Nulls cannot be represented by this collection.
+     * Attempting to add one will cause an {@link IllegalArgumentException} to
+     * be thrown.
+     */
+    @Override
+    public boolean add(T o) {
+        if (o == null)
+            throw new IllegalArgumentException("nulls not allowed");
 
-	/**
-	 * {@inheritDoc} NB: Nulls cannot be represented by this collection.
-	 * Attempting to add one will cause an {@link IllegalArgumentException} to
-	 * be thrown.
-	 */
-	@Override
-	public boolean add(String o) {
-		if (o == null)
-			throw new IllegalArgumentException("nulls not allowed");
+        try {
+            return this.addUnsynchronized(o);
+        } catch (KeeperException e) {
+            throw new RuntimeException(
+                    e.getClass().getSimpleName() + " caught", e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(
+                    e.getClass().getSimpleName() + " caught", e);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    e.getClass().getSimpleName() + " caught", e);
+        }
+    }
 
-		try {
-			return this.addUnsynchronized(o);
-		} catch (KeeperException e) {
-			throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-		}
-	}
+    /**
+     * {@inheritDoc} NB: Nulls cannot be represented by this collection.
+     * Attempting to add one will cause an {@link IllegalArgumentException} to
+     * be thrown.
+     */
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        boolean modified = false;
 
-	/**
-	 * {@inheritDoc} NB: Nulls cannot be represented by this collection.
-	 * Attempting to add one will cause an {@link IllegalArgumentException} to
-	 * be thrown.
-	 */
-	@Override
-	public boolean addAll(Collection<? extends String> c) {
-		boolean modified = false;
+        for (Object o : c) {
+            try {
+                if (o == null) {
+                    throw new IllegalArgumentException("nulls not allowed");
+                }
 
-		for (String s : c)
-			try {
-				if (s == null)
-					throw new IllegalArgumentException("nulls not allowed");
+                if (this.addUnsynchronized(o)) {
+                    modified = true;
+                }
+            } catch (KeeperException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            } catch (IOException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            }
+        }
 
-				if (this.addUnsynchronized(s))
-					modified = true;
-			} catch (KeeperException e) {
-				throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-			} catch (InterruptedException e) {
-				throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-			}
+        return modified;
+    }
 
-		return modified;
-	}
+    /** {@inheritDoc} */
+    @Override
+    public void clear() {
+        synchronized (this.elements) {
+            try {
+                for (String s : this.keeper.getChildren(this.znode,
+                        this.watcher))
+                    this.keeper.delete(this.znode + '/' + s, -1);
 
-	/** {@inheritDoc} */
-	@Override
-	public void clear() {
-		synchronized (this.elements) {
-			try {
-				for (String s : this.keeper.getChildren(this.znode, this.watcher))
-					this.keeper.delete(this.znode + '/' + s, -1);
+                this.synchronize();
+            } catch (KeeperException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            }
+        }
+    }
 
-				this.synchronize();
-			} catch (KeeperException e) {
-				throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-			} catch (InterruptedException e) {
-				throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-			}
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean contains(Object o) {
+        return this.elements.contains(o);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean contains(Object o) {
-		return this.elements.contains(o);
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        synchronized (this.elements) {
+            for (Object o : c)
+                if (!this.elements.contains(o))
+                    return false;
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean containsAll(Collection<?> c) {
-		synchronized (this.elements) {
-			for (Object o : c)
-				if (!this.elements.contains(o))
-					return false;
+            return true;
+        }
 
-			return true;
-		}
+    }
 
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean isEmpty() {
+        return this.elements.isEmpty();
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean isEmpty() {
-		return this.elements.isEmpty();
-	}
+    /** {@inheritDoc} */
+    @Override
+    public Iterator<T> iterator() {
+        return this.elements.iterator();
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public Iterator<String> iterator() {
-		return this.elements.iterator();
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean remove(Object o) {
+        try {
+            return this.removeUnsynchronized(o);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(
+                    e.getClass().getSimpleName() + " caught", e);
+        } catch (KeeperException e) {
+            throw new RuntimeException(
+                    e.getClass().getSimpleName() + " caught", e);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    e.getClass().getSimpleName() + " caught", e);
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean remove(Object o) {
-		try {
-			return this.removeUnsynchronized(o);
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-		} catch (KeeperException e) {
-			throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        synchronized (this.elements) {
+            try {
+                boolean modified = false;
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean removeAll(Collection<?> c) {
-		synchronized (this.elements) {
-			try {
-				boolean modified = false;
+                for (Object o : c)
+                    if (this.removeUnsynchronized(o))
+                        modified = true;
 
-				for (Object o : c)
-					if (this.removeUnsynchronized(o))
-						modified = true;
+                return modified;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            } catch (KeeperException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            } catch (IOException e) {
+                throw new RuntimeException(e.getClass().getSimpleName()
+                        + " caught", e);
+            }
+        }
+    }
 
-				return modified;
-			} catch (InterruptedException e) {
-				throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-			} catch (KeeperException e) {
-				throw new RuntimeException(e.getClass().getSimpleName() + " caught", e);
-			}
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        synchronized (this.elements) {
+            try {
+                // try not to copy unless necessary
+                Set<? extends Object> thatset;
+                if (c instanceof Set<?>)
+                    thatset = (Set<? extends Object>) c;
+                else
+                    thatset = new HashSet<Object>(c);
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean retainAll(Collection<?> c) {
-		synchronized (this.elements) {
-			try {
-				// try not to copy unless necessary
-				Set<? extends Object> thatset;
-				if (c instanceof Set<?>)
-					thatset = (Set<? extends Object>) c;
-				else
-					thatset = new HashSet<Object>(c);
+                boolean changed = false;
 
-				boolean changed = false;
+                for (Object o : this.elements)
+                    if (!thatset.contains(o) && this.removeUnsynchronized(o)
+                            && !changed)
+                        changed = true;
 
-				for (Object o : this.elements)
-					if (!thatset.contains(o) && this.removeUnsynchronized(o) && !changed)
-						changed = true;
+                return changed;
+            } catch (KeeperException e) {
+                throw new RuntimeException("KeeperException caught", e);
+            } catch (InterruptedException e) {
+                throw new RuntimeException("InterruptedException caught", e);
+            } catch (IOException e) {
+                throw new RuntimeException("IOException caught", e);
+            }
+        }
+    }
 
-				return changed;
-			} catch (KeeperException e) {
-				throw new RuntimeException("KeeperException caught", e);
-			} catch (InterruptedException e) {
-				throw new RuntimeException("InterruptedException caught", e);
-			}
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public int size() {
+        return this.elements.size();
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public int size() {
-		return this.elements.size();
-	}
+    /** {@inheritDoc} */
+    @Override
+    public Object[] toArray() {
+        return this.elements.toArray();
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public Object[] toArray() {
-		return this.elements.toArray();
-	}
+    /** {@inheritDoc} */
+    @SuppressWarnings("hiding")
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return this.elements.toArray(a);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public <T> T[] toArray(T[] a) {
-		return this.elements.toArray(a);
-	}
-
-	/** {@inheritDoc} */
-	@Override
-	public String toString() {
-		return this.elements.toString();
-	}
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return this.elements.toString();
+    }
 }

--- a/src/java/net/killa/kept/KeptLock.java
+++ b/src/java/net/killa/kept/KeptLock.java
@@ -37,147 +37,153 @@ import org.apache.zookeeper.data.Stat;
  * cluster.
  */
 public class KeptLock implements Lock {
-	private final ZooKeeper keeper;
-	private final String znode;
-	private final List<ACL> acl;
+    private final ZooKeeper keeper;
+    private final String znode;
+    private final List<ACL> acl;
 
-	/**
-	 * Construct a KeptLock.
-	 * 
-	 * @param keeper
-	 *            A {@link ZooKeeper} that is synchronized with
-	 * 
-	 * @param znode
-	 *            A {@link String} containing the znode that will serve as a
-	 *            lock
-	 * 
-	 * @param acl
-	 *            A {@link List} of {@link ACL} containing the access control
-	 *            lists for node creation
-	 * 
-	 * @throws KeeperException
-	 * @throws InterruptedException
-	 */
-	public KeptLock(ZooKeeper keeper, String znode, List<ACL> acl) throws KeeperException, InterruptedException {
-		this.keeper = keeper;
+    /**
+     * Construct a KeptLock.
+     * 
+     * @param keeper
+     *            A {@link ZooKeeper} that is synchronized with
+     * 
+     * @param znode
+     *            A {@link String} containing the znode that will serve as a
+     *            lock
+     * 
+     * @param acl
+     *            A {@link List} of {@link ACL} containing the access control
+     *            lists for node creation
+     * 
+     * @throws KeeperException
+     * @throws InterruptedException
+     */
+    public KeptLock(ZooKeeper keeper, String znode, List<ACL> acl)
+            throws KeeperException, InterruptedException {
+        this.keeper = keeper;
 
-		this.znode = znode;
-		this.acl = acl;
-	}
+        this.znode = znode;
+        this.acl = acl;
+    }
 
-	private boolean lockIt(long t, TimeUnit tu) throws KeeperException, InterruptedException {
-		final CountDownLatch latch = new CountDownLatch(1);
+    private boolean lockIt(long t, TimeUnit tu) throws KeeperException,
+            InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
 
-		// convert the given time to milliseconds and add it to the current time
-		long last = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(t, tu);
-		do {
-			if (this.keeper.exists(this.znode, new Watcher() {
-				@Override
-				public void process(WatchedEvent event) {
-					if (event.getType() == EventType.NodeDeleted)
-						latch.countDown();
-					else if (event.getType() == EventType.NodeCreated)
-						; // ignore it
-					else
-						throw new RuntimeException("unexpected event type" + event.getType());
-				}
-			}) != null) {
-				if (!latch.await(t, tu))
-					try {
-						this.keeper.create(this.znode, new byte[0], this.acl, CreateMode.EPHEMERAL);
+        // convert the given time to milliseconds and add it to the current time
+        long last = System.currentTimeMillis()
+                + TimeUnit.MILLISECONDS.convert(t, tu);
+        do {
+            if (this.keeper.exists(this.znode, new Watcher() {
+                @Override
+                public void process(WatchedEvent event) {
+                    if (event.getType() == EventType.NodeDeleted)
+                        latch.countDown();
+                    else if (event.getType() == EventType.NodeCreated)
+                        ; // ignore it
+                    else
+                        throw new RuntimeException("unexpected event type"
+                                + event.getType());
+                }
+            }) != null) {
+                if (!latch.await(t, tu))
+                    try {
+                        this.keeper.create(this.znode, new byte[0], this.acl,
+                                CreateMode.EPHEMERAL);
 
-						return true;
-					} catch (KeeperException.NodeExistsException e) {
-						// ignore it
-					} catch (KeeperException e) {
-						throw e;
-					}
-				else
-					return false;
-			} else {
-				try {
-					this.keeper.create(this.znode, new byte[0], this.acl, CreateMode.EPHEMERAL);
+                        return true;
+                    } catch (KeeperException.NodeExistsException e) {
+                        // ignore it
+                    } catch (KeeperException e) {
+                        throw e;
+                    }
+                else
+                    return false;
+            } else {
+                try {
+                    this.keeper.create(this.znode, new byte[0], this.acl,
+                            CreateMode.EPHEMERAL);
 
-					return true;
-				} catch (KeeperException.NodeExistsException e) {
-					// ignore it
-				} catch (KeeperException e) {
-					throw e;
-				}
-			}
-		} while (System.currentTimeMillis() < last);
+                    return true;
+                } catch (KeeperException.NodeExistsException e) {
+                    // ignore it
+                } catch (KeeperException e) {
+                    throw e;
+                }
+            }
+        } while (System.currentTimeMillis() < last);
 
-		return false;
-	}
+        return false;
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public void lock() {
-		// sleep until the client is unlocked. if interrupted, eat the exception
-		try {
-			this.lockIt(Long.MAX_VALUE, TimeUnit.DAYS);
-		} catch (KeeperException e) {
-			throw new RuntimeException("KeeperException caught", e);
-		} catch (InterruptedException e) {
-			// eat it
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public void lock() {
+        // sleep until the client is unlocked. if interrupted, eat the exception
+        try {
+            this.lockIt(Long.MAX_VALUE, TimeUnit.DAYS);
+        } catch (KeeperException e) {
+            throw new RuntimeException("KeeperException caught", e);
+        } catch (InterruptedException e) {
+            // eat it
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public void lockInterruptibly() throws InterruptedException {
-		// sleep until the client is unlocked. if interrupted, just pass the
-		// exception
-		try {
-			this.lockIt(Long.MAX_VALUE, TimeUnit.DAYS);
-		} catch (KeeperException e) {
-			throw new RuntimeException("KeeperException caught", e);
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public void lockInterruptibly() throws InterruptedException {
+        // sleep until the client is unlocked. if interrupted, just pass the
+        // exception
+        try {
+            this.lockIt(Long.MAX_VALUE, TimeUnit.DAYS);
+        } catch (KeeperException e) {
+            throw new RuntimeException("KeeperException caught", e);
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public Condition newCondition() {
-		// we don't support conditions.... yet?
-		throw new UnsupportedOperationException();
-	}
+    /** {@inheritDoc} */
+    @Override
+    public Condition newCondition() {
+        // we don't support conditions.... yet?
+        throw new UnsupportedOperationException();
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean tryLock() {
-		try {
-			return this.lockIt(0, TimeUnit.MICROSECONDS);
-		} catch (KeeperException e) {
-			throw new RuntimeException("KeeperException caught", e);
-		} catch (InterruptedException e) {
-			throw new RuntimeException("InterruptedException caught", e);
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean tryLock() {
+        try {
+            return this.lockIt(0, TimeUnit.MICROSECONDS);
+        } catch (KeeperException e) {
+            throw new RuntimeException("KeeperException caught", e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("InterruptedException caught", e);
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean tryLock(long t, TimeUnit tu) throws InterruptedException {
-		try {
-			return this.lockIt(t, tu);
-		} catch (KeeperException e) {
-			throw new RuntimeException("KeeperException caught", e);
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean tryLock(long t, TimeUnit tu) throws InterruptedException {
+        try {
+            return this.lockIt(t, tu);
+        } catch (KeeperException e) {
+            throw new RuntimeException("KeeperException caught", e);
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public void unlock() {
-		// check if we are already locked, throw an exception if so
-		try {
-			Stat stat;
-			if ((stat = this.keeper.exists(this.znode, false)) == null)
-				throw new IllegalStateException("already unlocked");
+    /** {@inheritDoc} */
+    @Override
+    public void unlock() {
+        // check if we are already locked, throw an exception if so
+        try {
+            Stat stat;
+            if ((stat = this.keeper.exists(this.znode, false)) == null)
+                throw new IllegalStateException("already unlocked");
 
-			this.keeper.delete(this.znode, stat.getVersion());
-		} catch (KeeperException e) {
-			throw new RuntimeException("KeeperException caught", e);
-		} catch (InterruptedException e) {
-			throw new RuntimeException("InterruptedException caught", e);
-		}
-	}
+            this.keeper.delete(this.znode, stat.getVersion());
+        } catch (KeeperException e) {
+            throw new RuntimeException("KeeperException caught", e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("InterruptedException caught", e);
+        }
+    }
 }

--- a/src/java/net/killa/kept/KeptQueue.java
+++ b/src/java/net/killa/kept/KeptQueue.java
@@ -35,71 +35,72 @@ import org.apache.zookeeper.data.ACL;
  * may be a delay between modifying the queue and it reflecting the change.
  * 
  */
-public class KeptQueue extends KeptList implements Queue<String> {
-	/**
-	 * Construct a KeptQueue.
-	 * 
-	 * @param keeper
-	 *            A {@link ZooKeeper} that is synchronized with
-	 * 
-	 * @param znode
-	 *            A {@link String} containing the znode whose children will be
-	 *            members of the set
-	 * 
-	 * @param acl
-	 *            A {@link List} of {@link ACL} containing the access control
-	 *            lists for child node creation
-	 * 
-	 * @param mode
-	 *            A {@link CreateMode} representing the persistence of created
-	 *            child nodes
-	 * 
-	 * @throws KeeperException
-	 * @throws InterruptedException
-	 */
-	public KeptQueue(ZooKeeper keeper, String znode, List<ACL> acl, CreateMode mode) throws KeeperException, InterruptedException {
-		super(keeper, znode, acl, mode);
-	}
+public class KeptQueue<T> extends KeptList<T> implements Queue<T> {
+    /**
+     * Construct a KeptQueue.
+     * 
+     * @param keeper
+     *            A {@link ZooKeeper} that is synchronized with
+     * 
+     * @param znode
+     *            A {@link String} containing the znode whose children will be
+     *            members of the set
+     * 
+     * @param acl
+     *            A {@link List} of {@link ACL} containing the access control
+     *            lists for child node creation
+     * 
+     * @param mode
+     *            A {@link CreateMode} representing the persistence of created
+     *            child nodes
+     * 
+     * @throws KeeperException
+     * @throws InterruptedException
+     */
+    public KeptQueue(ZooKeeper keeper, String znode, List<ACL> acl,
+            CreateMode mode) throws KeeperException, InterruptedException {
+        super(keeper, znode, acl, mode);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public String element() {
-		if (this.size() == 0)
-			throw new NoSuchElementException();
+    /** {@inheritDoc} */
+    @Override
+    public T element() {
+        if (this.size() == 0)
+            throw new NoSuchElementException();
 
-		return this.get(0);
-	}
+        return this.get(0);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean offer(String o) {
-		return this.add(o);
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean offer(T o) {
+        return this.add(o);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public String peek() {
-		if (this.size() == 0)
-			return null;
+    /** {@inheritDoc} */
+    @Override
+    public T peek() {
+        if (this.size() == 0)
+            return null;
 
-		return this.get(0);
-	}
+        return this.get(0);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public String poll() {
-		if (this.size() == 0)
-			return null;
+    /** {@inheritDoc} */
+    @Override
+    public T poll() {
+        if (this.size() == 0)
+            return null;
 
-		return this.remove(0);
-	}
+        return this.remove(0);
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public String remove() {
-		if (this.size() == 0)
-			throw new NoSuchElementException();
+    /** {@inheritDoc} */
+    @Override
+    public T remove() {
+        if (this.size() == 0)
+            throw new NoSuchElementException();
 
-		return this.remove(0);
-	}
+        return this.remove(0);
+    }
 }

--- a/src/java/net/killa/kept/Transformer.java
+++ b/src/java/net/killa/kept/Transformer.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.killa.kept;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+final class Transformer {
+    static String objectToString(final Object object) throws IOException {
+        return bytesToString(objectToBytes(object));
+    }
+
+    static Object stringToObject(final String string) throws IOException,
+            ClassNotFoundException {
+        return bytesToObject(stringToBytes(string));
+    }
+
+    static byte[] objectToBytes(final Object object) throws IOException {
+        byte[] bytes = null;
+        if (object != null) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = null;
+            try {
+                oos = new ObjectOutputStream(baos);
+                oos.writeObject(object);
+                bytes = baos.toByteArray();
+            } finally {
+                baos.close();
+                oos.close();
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "Cannot byte-transform null object");
+        }
+
+        return bytes;
+    }
+
+    static String bytesToString(final byte[] bytes) {
+        String transformed = null;
+        if (bytes != null && bytes.length != 0) {
+            StringBuilder hexString = new StringBuilder(2 * bytes.length);
+            for (byte bite : bytes) {
+                hexString.append("0123456789ABCDEF".charAt((bite & 0xF0) >> 4))
+                        .append("0123456789ABCDEF".charAt((bite & 0x0F)));
+            }
+            transformed = hexString.toString();
+        } else {
+            throw new IllegalArgumentException(
+                    "Cannot string-transform null or empty byte array");
+        }
+
+        return transformed;
+    }
+
+    static Object bytesToObject(final byte[] bytes) throws IOException,
+            ClassNotFoundException {
+        Object object = null;
+        if (bytes != null && bytes.length != 0) {
+            InputStream is = null;
+            ObjectInputStream ois = null;
+            try {
+                is = new ByteArrayInputStream(bytes);
+                ois = new ObjectInputStream(is);
+                object = ois.readObject();
+            } finally {
+                is.close();
+                ois.close();
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "Cannot object-transform null or empty byte array");
+        }
+
+        return object;
+    }
+
+    static byte[] stringToBytes(final String string) {
+        byte[] bytes = null;
+        if (string != null && string.length() != 0) {
+            bytes = new byte[string.length() / 2];
+            for (int i = 0, j = 0; i < bytes.length;) {
+                char upper = Character.toLowerCase(string.charAt(j++));
+                char lower = Character.toLowerCase(string.charAt(j++));
+                bytes[i++] = (byte) ((Character.digit(upper, 16) << 4) | Character
+                        .digit(lower, 16));
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "Cannot byte-transform null or empty string");
+        }
+
+        return bytes;
+    }
+
+    private Transformer() {
+    }
+}

--- a/src/test/net/killa/kept/BaseKeptUtil.java
+++ b/src/test/net/killa/kept/BaseKeptUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.killa.kept;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+
+public class BaseKeptUtil {
+    protected String parent;
+    protected ZooKeeper keeper;
+
+    @Before
+    public void before() throws IOException, InterruptedException,
+            KeeperException {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // FIXME: set up a zookeeper server in process
+        CountDownOnConnectWatcher watcher = new CountDownOnConnectWatcher();
+        watcher.setLatch(latch);
+        this.keeper = new ZooKeeper("localhost:2181", 20000, watcher);
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("unable to connect to server");
+        }
+    }
+
+    @After
+    public void after() throws InterruptedException, KeeperException {
+        for (String s : this.keeper.getChildren(parent, false)) {
+            this.keeper.delete(parent + '/' + s, -1);
+        }
+        this.keeper.close();
+    }
+}

--- a/src/test/net/killa/kept/SerializablePerson.java
+++ b/src/test/net/killa/kept/SerializablePerson.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.killa.kept;
+
+class SerializablePerson implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+    String name;
+    int age;
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + age;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof SerializablePerson)) {
+            return false;
+        }
+        SerializablePerson other = (SerializablePerson) obj;
+        if (age != other.age) {
+            return false;
+        }
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/test/net/killa/kept/TransformerTest.java
+++ b/src/test/net/killa/kept/TransformerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.killa.kept;
+
+import java.io.NotSerializableException;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+public class TransformerTest {
+    @Test
+    public void testSerDeser() throws Exception {
+        SerializablePerson toFlatten = new SerializablePerson();
+        toFlatten.name = "testName";
+        toFlatten.age = 300;
+        String string = Transformer.objectToString(toFlatten);
+        SerializablePerson deflattened = (SerializablePerson) Transformer
+                .stringToObject(string);
+        Assert.assertEquals(toFlatten.name, deflattened.name);
+        Assert.assertEquals(toFlatten.age, deflattened.age);
+    }
+
+    @Test(expected = NotSerializableException.class)
+    public void testSerDeserNonserializable() throws Exception {
+        TestNonserializableObject toFlatten = new TestNonserializableObject();
+        toFlatten.name = "testName";
+        toFlatten.age = 300;
+        Transformer.objectToString(toFlatten);
+    }
+
+    static class TestNonserializableObject {
+        @SuppressWarnings("unused")
+        private String name;
+        @SuppressWarnings("unused")
+        private int age;
+    }
+}


### PR DESCRIPTION
Hello Anthony,

This pull-request concentrates on the following two topics: 
1. enhancements to support any object type presently for KeptList, Queue, BlockingQueue, Collection, and 
2. genericized aforementioned keptcollections.

I am still working on KeptSet and Map enhancements; to follow in sometime. Also, I just realized during commit that my eclipse format-on-save seems to have altered the code formatting to unix-style tabless / space-only format. Please let me know if you would like me to either revert to your tabbed format or share my formatter for you to easily discern the diff's.

Thanks,
Gaurav
