### PR TITLE
Serialization performance improvements

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -64,7 +64,7 @@
 			<classpath refid="classpath" />
 			<batchtest>
 				<formatter type="plain" usefile="false" />
-				<fileset dir="build/testclasses" includes="**/Test*.class" />
+				<fileset dir="build/testclasses" includes="**/*Test*.class" />
 			</batchtest>
 		</junit>
 	</target>

--- a/src/java/net/killa/kept/KeptBlockingQueue.java
+++ b/src/java/net/killa/kept/KeptBlockingQueue.java
@@ -59,9 +59,10 @@ public class KeptBlockingQueue<T> extends KeptQueue<T> implements
      * @throws KeeperException
      * @throws InterruptedException
      */
-    public KeptBlockingQueue(ZooKeeper keeper, String znode, List<ACL> acl,
-	    CreateMode mode) throws KeeperException, InterruptedException {
-	super(keeper, znode, acl, mode);
+    public KeptBlockingQueue(final Class<? extends T> elementClass,
+	    final ZooKeeper keeper, final String znode, final List<ACL> acl,
+	    final CreateMode mode) throws KeeperException, InterruptedException {
+	super(elementClass, keeper, znode, acl, mode);
     }
 
     /** {@inheritDoc} */

--- a/src/java/net/killa/kept/KeptQueue.java
+++ b/src/java/net/killa/kept/KeptQueue.java
@@ -57,9 +57,10 @@ public class KeptQueue<T> extends KeptList<T> implements Queue<T> {
      * @throws KeeperException
      * @throws InterruptedException
      */
-    public KeptQueue(ZooKeeper keeper, String znode, List<ACL> acl,
-	    CreateMode mode) throws KeeperException, InterruptedException {
-	super(keeper, znode, acl, mode);
+    public KeptQueue(final Class<? extends T> elementClass,
+	    final ZooKeeper keeper, final String znode, final List<ACL> acl,
+	    final CreateMode mode) throws KeeperException, InterruptedException {
+	super(elementClass, keeper, znode, acl, mode);
     }
 
     /** {@inheritDoc} */

--- a/src/java/net/killa/kept/Transformer.java
+++ b/src/java/net/killa/kept/Transformer.java
@@ -19,33 +19,47 @@ package net.killa.kept;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 final class Transformer {
-    static String objectToString(final Object object) throws IOException {
-	return Transformer.bytesToString(Transformer.objectToBytes(object));
+    static String objectToString(final Object object, final Class<?> objectType)
+	    throws IOException {
+	return Transformer.bytesToString(Transformer.objectToBytes(object,
+		objectType));
     }
 
-    static Object stringToObject(final String string) throws IOException,
-	    ClassNotFoundException {
-	return Transformer.bytesToObject(Transformer.stringToBytes(string));
+    static Object stringToObject(final String string, final Class<?> objectType)
+	    throws IOException, ClassNotFoundException {
+	return Transformer.bytesToObject(Transformer.stringToBytes(string),
+		objectType);
     }
 
-    static byte[] objectToBytes(final Object object) throws IOException {
+    static byte[] objectToBytes(final Object object, final Class<?> objectType)
+	    throws IOException {
 	byte[] bytes = null;
 	if (object != null) {
-	    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-	    ObjectOutputStream oos = null;
-	    try {
-		oos = new ObjectOutputStream(baos);
-		oos.writeObject(object);
-		bytes = baos.toByteArray();
-	    } finally {
-		baos.close();
-		oos.close();
+	    if (STRINGIFIABLE_PRIMITIVES.contains(objectType)) {
+		bytes = object.toString().getBytes();
+	    } else {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = null;
+		try {
+		    oos = new ObjectOutputStream(baos);
+		    oos.writeObject(object);
+		    bytes = baos.toByteArray();
+		} finally {
+		    close(baos);
+		    close(oos);
+		}
 	    }
 	} else {
 	    throw new IllegalArgumentException(
@@ -72,19 +86,23 @@ final class Transformer {
 	return transformed;
     }
 
-    static Object bytesToObject(final byte[] bytes) throws IOException,
-	    ClassNotFoundException {
+    static Object bytesToObject(final byte[] bytes, final Class<?> objectType)
+	    throws IOException, ClassNotFoundException {
 	Object object = null;
 	if (bytes != null && bytes.length != 0) {
-	    InputStream is = null;
-	    ObjectInputStream ois = null;
-	    try {
-		is = new ByteArrayInputStream(bytes);
-		ois = new ObjectInputStream(is);
-		object = ois.readObject();
-	    } finally {
-		is.close();
-		ois.close();
+	    if (STRINGIFIABLE_PRIMITIVES.contains(objectType)) {
+		object = transform(objectType, new String(bytes));
+	    } else {
+		InputStream is = null;
+		ObjectInputStream ois = null;
+		try {
+		    is = new ByteArrayInputStream(bytes);
+		    ois = new ObjectInputStream(is);
+		    object = ois.readObject();
+		} finally {
+		    close(is);
+		    close(ois);
+		}
 	    }
 	} else {
 	    throw new IllegalArgumentException(
@@ -110,6 +128,104 @@ final class Transformer {
 	}
 
 	return bytes;
+    }
+
+    private static Object transform(final Class<?> type,
+	    final String toTransform) {
+	if (type.equals(String.class)) {
+	    return toTransform;
+	}
+	if (type.equals(Byte.class) || type.equals(byte.class)) {
+	    return new Byte(toTransform);
+	}
+	if (type.equals(Character.class) || type.equals(char.class)) {
+	    if (!isNullOrEmpty(toTransform)) {
+		if (toTransform.length() > 1) {
+		    throw new IllegalArgumentException(
+			    "Non-character value masquerading as characters in a string");
+		}
+		return toTransform.charAt(0);
+	    } else {
+		return '\u0000';
+	    }
+	}
+	if (type.equals(Short.class) || type.equals(short.class)) {
+	    return new Short(toTransform);
+	}
+	if (type.equals(Integer.class) || type.equals(int.class)) {
+	    if (toTransform == null) {
+		return 0;
+	    }
+	    return new Integer(toTransform);
+	}
+	if (type.equals(Float.class) || type.equals(float.class)) {
+	    if (toTransform == null) {
+		return 0f;
+	    }
+	    return new Float(toTransform);
+	}
+	if (type.equals(Double.class) || type.equals(double.class)) {
+	    return new Double(toTransform);
+	}
+	if (type.equals(Long.class) || type.equals(long.class)) {
+	    return new Long(toTransform);
+	}
+	if (type.equals(Boolean.class) || type.equals(boolean.class)) {
+	    return new Boolean(toTransform);
+	}
+	if (type.equals(BigDecimal.class)) {
+	    return new BigDecimal(toTransform);
+	}
+	if (type.equals(BigInteger.class)) {
+	    return new BigInteger(toTransform);
+	}
+
+	return toTransform;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean isNullOrEmpty(final Object obj) {
+	if (obj == null) {
+	    return true;
+	}
+	if (obj.getClass().equals(Collection.class)) {
+	    return ((Collection) obj).size() == 0;
+	} else {
+	    if (obj.toString().trim().length() == 0) {
+		return true;
+	    }
+	}
+
+	return false;
+    }
+
+    private static void close(final Closeable stream) throws IOException {
+	if (stream != null) {
+	    stream.close();
+	}
+    }
+
+    static final Set<Class<?>> STRINGIFIABLE_PRIMITIVES = new HashSet<Class<?>>();
+    static {
+	STRINGIFIABLE_PRIMITIVES.add(String.class);
+	STRINGIFIABLE_PRIMITIVES.add(Byte.class);
+	STRINGIFIABLE_PRIMITIVES.add(byte.class);
+	STRINGIFIABLE_PRIMITIVES.add(Character.class);
+	STRINGIFIABLE_PRIMITIVES.add(char.class);
+	STRINGIFIABLE_PRIMITIVES.add(Short.class);
+	STRINGIFIABLE_PRIMITIVES.add(short.class);
+	STRINGIFIABLE_PRIMITIVES.add(Integer.class);
+	STRINGIFIABLE_PRIMITIVES.add(int.class);
+	STRINGIFIABLE_PRIMITIVES.add(Float.class);
+	STRINGIFIABLE_PRIMITIVES.add(float.class);
+	STRINGIFIABLE_PRIMITIVES.add(Double.class);
+	STRINGIFIABLE_PRIMITIVES.add(double.class);
+	STRINGIFIABLE_PRIMITIVES.add(Long.class);
+	STRINGIFIABLE_PRIMITIVES.add(long.class);
+	STRINGIFIABLE_PRIMITIVES.add(Boolean.class);
+	STRINGIFIABLE_PRIMITIVES.add(boolean.class);
+	STRINGIFIABLE_PRIMITIVES.add(BigDecimal.class);
+	STRINGIFIABLE_PRIMITIVES.add(BigInteger.class);
     }
 
     private Transformer() {

--- a/src/test/net/killa/kept/NonSerializablePerson.java
+++ b/src/test/net/killa/kept/NonSerializablePerson.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.killa.kept;
+
+class NonserializablePerson {
+    String name;
+    int age;
+}

--- a/src/test/net/killa/kept/TestKeptBlockingQueue.java
+++ b/src/test/net/killa/kept/TestKeptBlockingQueue.java
@@ -34,7 +34,7 @@ public class TestKeptBlockingQueue extends BaseKeptUtil {
     @Test
     public void testKeptStringQueue() throws Exception {
 	KeptBlockingQueue<String> kbq = new KeptBlockingQueue<String>(
-		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
+		String.class, this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
 		CreateMode.EPHEMERAL);
 
 	Assert.assertNull(kbq.poll(1, TimeUnit.SECONDS));

--- a/src/test/net/killa/kept/TestKeptCollection.java
+++ b/src/test/net/killa/kept/TestKeptCollection.java
@@ -36,8 +36,9 @@ public class TestKeptCollection extends BaseKeptUtil {
     @Test
     public void testKeptCollection() throws IOException, KeeperException,
 	    InterruptedException {
-	KeptCollection<String> kc = new KeptCollection<String>(this.keeper,
-		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptCollection<String> kc = new KeptCollection<String>(String.class,
+		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
+		CreateMode.EPHEMERAL);
 
 	// check to see that changes made to the collection are reflected in the
 	// znode
@@ -69,8 +70,8 @@ public class TestKeptCollection extends BaseKeptUtil {
 	Assert.assertFalse(kc.contains(payload));
 
 	String fullPath = this.keeper.create(this.parent + "/node-",
-		Transformer.objectToBytes(payload), Ids.OPEN_ACL_UNSAFE,
-		CreateMode.EPHEMERAL);
+		Transformer.objectToBytes(payload, String.class),
+		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	// wait for it to take effect
 	Thread.sleep(100);
@@ -89,8 +90,9 @@ public class TestKeptCollection extends BaseKeptUtil {
     @Test
     public void testKeptCollectionClear() throws IOException, KeeperException,
 	    InterruptedException {
-	KeptCollection<String> ks = new KeptCollection<String>(this.keeper,
-		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptCollection<String> ks = new KeptCollection<String>(String.class,
+		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
+		CreateMode.EPHEMERAL);
 
 	ks.add("one");
 	ks.add("two");
@@ -99,10 +101,14 @@ public class TestKeptCollection extends BaseKeptUtil {
 	// wait for it to take effect
 	Thread.sleep(100);
 
-	Assert.assertTrue("collection does not contain one", ks.contains("one"));
-	Assert.assertTrue("collection does not contain two", ks.contains("two"));
-	Assert.assertTrue("collection does not contain three",
-		ks.contains("three"));
+	Assert
+		.assertTrue("collection does not contain one", ks
+			.contains("one"));
+	Assert
+		.assertTrue("collection does not contain two", ks
+			.contains("two"));
+	Assert.assertTrue("collection does not contain three", ks
+		.contains("three"));
 
 	ks.clear();
 
@@ -123,8 +129,9 @@ public class TestKeptCollection extends BaseKeptUtil {
 	hs.add("two");
 	hs.add("three");
 
-	KeptCollection<String> s = new KeptCollection<String>(this.keeper,
-		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptCollection<String> s = new KeptCollection<String>(String.class,
+		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
+		CreateMode.EPHEMERAL);
 
 	s.addAll(hs);
 
@@ -160,8 +167,9 @@ public class TestKeptCollection extends BaseKeptUtil {
 	al2.add("three");
 	al2.add("four");
 
-	KeptCollection<String> kc = new KeptCollection<String>(this.keeper,
-		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptCollection<String> kc = new KeptCollection<String>(String.class,
+		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
+		CreateMode.EPHEMERAL);
 
 	kc.addAll(al1);
 
@@ -174,17 +182,20 @@ public class TestKeptCollection extends BaseKeptUtil {
 	// wait for it to take effect
 	Thread.sleep(100);
 
-	Assert.assertTrue("collection does not contain all", kc.contains("two"));
-	Assert.assertTrue("collection does not contain all",
-		kc.contains("three"));
+	Assert
+		.assertTrue("collection does not contain all", kc
+			.contains("two"));
+	Assert.assertTrue("collection does not contain all", kc
+		.contains("three"));
 	Assert.assertEquals("collection is the wrong size", 2, kc.size());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testKeptCollectionAddNull() throws IOException,
 	    KeeperException, InterruptedException {
-	KeptCollection<Object> kc = new KeptCollection<Object>(this.keeper,
-		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptCollection<Object> kc = new KeptCollection<Object>(String.class,
+		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
+		CreateMode.EPHEMERAL);
 
 	kc.add(null);
     }
@@ -192,8 +203,9 @@ public class TestKeptCollection extends BaseKeptUtil {
     @Test(expected = IllegalArgumentException.class)
     public void testKeptCollectionAddAllNull() throws IOException,
 	    KeeperException, InterruptedException {
-	KeptCollection<String> kc = new KeptCollection<String>(this.keeper,
-		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptCollection<String> kc = new KeptCollection<String>(String.class,
+		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
+		CreateMode.EPHEMERAL);
 
 	kc.addAll(Arrays.asList(new String[] { null }));
     }

--- a/src/test/net/killa/kept/TestKeptList.java
+++ b/src/test/net/killa/kept/TestKeptList.java
@@ -30,8 +30,8 @@ public class TestKeptList extends BaseKeptUtil {
 
     @Test
     public void testKeptStringList() throws Exception {
-	KeptList<String> kl = new KeptList<String>(this.keeper, this.parent,
-		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptList<String> kl = new KeptList<String>(String.class, this.keeper,
+		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	String payload = Long.toString(System.currentTimeMillis());
 	Thread.sleep(100);
@@ -60,8 +60,8 @@ public class TestKeptList extends BaseKeptUtil {
 
     @Test
     public void testKeptLongList() throws Exception {
-	KeptList<Long> kl = new KeptList<Long>(this.keeper, this.parent,
-		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptList<Long> kl = new KeptList<Long>(Long.class, this.keeper,
+		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	long payload = System.currentTimeMillis();
 	Thread.sleep(100);
@@ -91,8 +91,8 @@ public class TestKeptList extends BaseKeptUtil {
     @Test
     public void testKeptNonprimitiveList() throws Exception {
 	KeptList<SerializablePerson> kl = new KeptList<SerializablePerson>(
-		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
-		CreateMode.EPHEMERAL);
+		SerializablePerson.class, this.keeper, this.parent,
+		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	SerializablePerson person1 = new SerializablePerson();
 	person1.age = 100;
@@ -133,8 +133,8 @@ public class TestKeptList extends BaseKeptUtil {
     @Test(expected = IndexOutOfBoundsException.class)
     public void testKeptCollectionBigIndex() throws KeeperException,
 	    InterruptedException {
-	KeptList<String> kl = new KeptList<String>(this.keeper, this.parent,
-		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptList<String> kl = new KeptList<String>(String.class, this.keeper,
+		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	kl.set(Integer.MAX_VALUE, "wtf");
     }

--- a/src/test/net/killa/kept/TestKeptQueue.java
+++ b/src/test/net/killa/kept/TestKeptQueue.java
@@ -33,8 +33,8 @@ public class TestKeptQueue extends BaseKeptUtil {
 
     @Test
     public void testKeptStringQueue() throws Exception {
-	KeptQueue<String> kq = new KeptQueue<String>(this.keeper, this.parent,
-		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptQueue<String> kq = new KeptQueue<String>(String.class, this.keeper,
+		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	String payload1 = Long.toString(System.currentTimeMillis());
 	Thread.sleep(100);
@@ -71,8 +71,8 @@ public class TestKeptQueue extends BaseKeptUtil {
     @Test
     public void testKeptNonPrimitiveQueue() throws Exception {
 	KeptQueue<SerializablePerson> kq = new KeptQueue<SerializablePerson>(
-		this.keeper, this.parent, Ids.OPEN_ACL_UNSAFE,
-		CreateMode.EPHEMERAL);
+		SerializablePerson.class, this.keeper, this.parent,
+		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	SerializablePerson person1 = new SerializablePerson();
 	person1.age = 50;
@@ -113,8 +113,8 @@ public class TestKeptQueue extends BaseKeptUtil {
     @Test(expected = NoSuchElementException.class)
     public void testKeptQueueEmptyElement() throws IOException,
 	    KeeperException, InterruptedException {
-	KeptQueue<Object> kq = new KeptQueue<Object>(this.keeper, this.parent,
-		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptQueue<Object> kq = new KeptQueue<Object>(Object.class, this.keeper,
+		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	kq.element();
     }
@@ -122,8 +122,8 @@ public class TestKeptQueue extends BaseKeptUtil {
     @Test(expected = NoSuchElementException.class)
     public void testKeptQueueEmptyRemove() throws IOException, KeeperException,
 	    InterruptedException {
-	KeptQueue<Object> kq = new KeptQueue<Object>(this.keeper, this.parent,
-		Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+	KeptQueue<Object> kq = new KeptQueue<Object>(Object.class, this.keeper,
+		this.parent, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
 	kq.remove();
     }

--- a/src/test/net/killa/kept/TransformerTest.java
+++ b/src/test/net/killa/kept/TransformerTest.java
@@ -29,25 +29,91 @@ public class TransformerTest {
 	SerializablePerson toFlatten = new SerializablePerson();
 	toFlatten.name = "testName";
 	toFlatten.age = 300;
-	String string = Transformer.objectToString(toFlatten);
+	String string = Transformer.objectToString(toFlatten,
+		SerializablePerson.class);
 	SerializablePerson deflattened = (SerializablePerson) Transformer
-		.stringToObject(string);
+		.stringToObject(string, SerializablePerson.class);
 	Assert.assertEquals(toFlatten.name, deflattened.name);
 	Assert.assertEquals(toFlatten.age, deflattened.age);
     }
 
     @Test(expected = NotSerializableException.class)
     public void testSerDeserNonserializable() throws Exception {
-	TestNonserializableObject toFlatten = new TestNonserializableObject();
+	NonserializablePerson toFlatten = new NonserializablePerson();
 	toFlatten.name = "testName";
 	toFlatten.age = 300;
-	Transformer.objectToString(toFlatten);
+	Transformer.objectToString(toFlatten, NonserializablePerson.class);
     }
 
-    static class TestNonserializableObject {
-	@SuppressWarnings("unused")
-	private String name;
-	@SuppressWarnings("unused")
-	private int age;
+    @Test
+    public void testSerDeserIntPerf() throws Exception {
+	long startNanos = System.nanoTime();
+	for (int i = 0; i < 10000; i++) {
+	    Assert.assertEquals(i, Transformer.bytesToObject(Transformer
+		    .objectToBytes(i, int.class), int.class));
+	}
+	long elapsed1 = System.nanoTime() - startNanos;
+
+	Transformer.STRINGIFIABLE_PRIMITIVES.remove(int.class);
+
+	startNanos = System.nanoTime();
+	for (int i = 0; i < 10000; i++) {
+	    Assert.assertEquals(i, Transformer.bytesToObject(Transformer
+		    .objectToBytes(i, int.class), int.class));
+	}
+	long elapsed2 = System.nanoTime() - startNanos;
+	Assert.assertTrue(elapsed2 > elapsed1);
+	Assert.assertTrue(elapsed2 > 4 * elapsed1);
+	System.out.println("Stringified serDeser (10k ints) nanos=" + elapsed1
+		+ "\nNon-Stringified serDeser (10k ints) nanos=" + elapsed2);
+    }
+
+    @Test
+    public void testSerDeserLongPerf() throws Exception {
+	long startNanos = System.nanoTime();
+	for (long i = 0; i < 10000L; i++) {
+	    Assert.assertEquals(i, Transformer.bytesToObject(Transformer
+		    .objectToBytes(i, long.class), long.class));
+	}
+	long elapsed1 = System.nanoTime() - startNanos;
+
+	Transformer.STRINGIFIABLE_PRIMITIVES.remove(long.class);
+
+	startNanos = System.nanoTime();
+	for (long i = 0; i < 10000L; i++) {
+	    Assert.assertEquals(i, Transformer.bytesToObject(Transformer
+		    .objectToBytes(i, long.class), long.class));
+	}
+	long elapsed2 = System.nanoTime() - startNanos;
+	Assert.assertTrue(elapsed2 > elapsed1);
+	Assert.assertTrue(elapsed2 > 10 * elapsed1);
+	System.out.println("Stringified serDeser (10k longs) nanos=" + elapsed1
+		+ "\nNon-Stringified serDeser (10k longs) nanos=" + elapsed2);
+    }
+
+    @Test
+    public void testSerDeserStringPerf() throws Exception {
+	long startNanos = System.nanoTime();
+	for (long i = 0; i < 10000L; i++) {
+	    Assert.assertEquals("String" + i, Transformer.bytesToObject(
+		    Transformer.objectToBytes("String" + i, String.class),
+		    String.class));
+	}
+	long elapsed1 = System.nanoTime() - startNanos;
+
+	Transformer.STRINGIFIABLE_PRIMITIVES.remove(String.class);
+
+	startNanos = System.nanoTime();
+	for (long i = 0; i < 10000L; i++) {
+	    Assert.assertEquals("String" + i, Transformer.bytesToObject(
+		    Transformer.objectToBytes("String" + i, String.class),
+		    String.class));
+	}
+	long elapsed2 = System.nanoTime() - startNanos;
+	Assert.assertTrue(elapsed2 > elapsed1);
+	Assert.assertTrue(elapsed2 > 4 * elapsed1);
+	System.out.println("Stringified serDeser (10k strings) nanos="
+		+ elapsed1 + "\nNon-Stringified serDeser (10k strings) nanos="
+		+ elapsed2);
     }
 }


### PR DESCRIPTION
Major serialization performance improvements via type-checking of string-friendly collection element types enabled by type-injection into keptcollections. Presently supporting descendants of List ADT only.
